### PR TITLE
Include libsemigroups headers as libsemigroups/*.hpp

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -4,9 +4,40 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'PythonElement' from '' (unknown location)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-54e6cd59994d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mlibsemigroups_cppyy\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mTransformation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mPermutation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mBooleanMat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFroidurePin\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/opt/libsemigroups_cppyy/libsemigroups_cppyy/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     50\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mlibsemigroups_cppyy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdigraph\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mActionDigraph\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     51\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 52\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mcppyy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgbl\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mPythonElement\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     53\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mcppyy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgbl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlibsemigroups\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mReportGuard\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     54\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'PythonElement' from '' (unknown location)"
+     ]
+    }
+   ],
    "source": [
     "from libsemigroups_cppyy import Transformation, Permutation, BooleanMat, FroidurePin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cppyy.gbl.libsemigroups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cppyy.gbl.libsemigroups."
    ]
   },
   {
@@ -51,31 +82,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "S = FroidurePin(Permutation([1, 2, 3, 0]), Permutation([1, 0, 2, 3]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "24"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "S.size()"
    ]
   },
   {
@@ -86,10 +97,30 @@
     {
      "data": {
       "text/plain": [
-       "1"
+       "24"
       ]
      },
      "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "S.size()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -100,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +152,7 @@
        "63904"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -132,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -141,7 +172,7 @@
        "2360"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,13 +180,203 @@
    "source": [
     "S.nr_idempotents()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "S.nr_generators()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gens = [S.generator(i) for i in range(S.nr_generators())]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a,b,c,d = gens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.is_regular_element()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "01000000\n",
+       "00100000\n",
+       "00010000\n",
+       "10000000\n",
+       "00000000\n",
+       "00000000\n",
+       "00000000\n",
+       "00000000\n"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "00010000\n",
+       "10000000\n",
+       "01000000\n",
+       "00100000\n",
+       "00000000\n",
+       "00000000\n",
+       "00000000\n",
+       "00000000\n"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.transpose()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recovering the left and right Cayley graphs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L = S.left_cayley_graph()\n",
+    "R = S.right_cayley_graph()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import libsemigroups_cppyy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recovering the left and right classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "libsemigroups_cppyy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Computing a semigroup using Schreier?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from libsemigroups_cppyy import SchreierSims"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "could not construct C++ name from provided template argument. (<string>)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<string>\"\u001b[0;36m, line \u001b[0;32munknown\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m could not construct C++ name from provided template argument.\n"
+     ]
+    }
+   ],
+   "source": [
+    "S = SchreierSims(Permutation([1, 2, 3, 0]), Permutation([1, 0, 2, 3]))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "SageMath 9.0",
+   "language": "sage",
+   "name": "sagemath"
   },
   "language_info": {
    "codemirror_mode": {
@@ -167,7 +388,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/include/python_element.h
+++ b/include/python_element.h
@@ -1,7 +1,7 @@
 #include <Python.h>
 
-#include "adapters.hpp"
-#include "constants.hpp"
+#include "libsemigroups/adapters.hpp"
+#include "libsemigroups/constants.hpp"
 
 class PythonElement {
  private:

--- a/libsemigroups_cppyy/__init__.py
+++ b/libsemigroups_cppyy/__init__.py
@@ -21,21 +21,18 @@ from cppyy.gbl import std
 import libsemigroups_cppyy.detail
 from libsemigroups_cppyy.adapters import *
 
-cppyy.add_include_path("/usr/local/include/libsemigroups/fmt")
-cppyy.add_include_path("/usr/local/include/libsemigroups")
-
 cppyy.load_library("libsemigroups")
 
 cppyy.cppdef("#define FMT_HEADER_ONLY")
 cppyy.cppdef("#define HPCOMBI_CONSTEXPR_FUN_ARGS")
 
-cppyy.include("action.hpp")
-cppyy.include("bmat8.hpp")
-cppyy.include("element.hpp")
-cppyy.include("element-helper.hpp")
-cppyy.include("froidure-pin.hpp")
-cppyy.include("schreier-sims.hpp")
-cppyy.include("report.hpp")
+cppyy.include("libsemigroups/action.hpp")
+cppyy.include("libsemigroups/bmat8.hpp")
+cppyy.include("libsemigroups/element.hpp")
+cppyy.include("libsemigroups/element-helper.hpp")
+cppyy.include("libsemigroups/froidure-pin.hpp")
+cppyy.include("libsemigroups/schreier-sims.hpp")
+cppyy.include("libsemigroups/report.hpp")
 
 cppyy.include("include/python_element.h")
 


### PR DESCRIPTION
Benefits:
- no more need for extending the include path with libsemigroup's
  include location
- that location was hardcoded as /usr/local/, which prevented use when
  libsemigroups was installed elsewhere; e.g. in Sage.