### PR TITLE
Fix test failure problem related to cppyy version

### DIFF
--- a/libsemigroups_cppyy/__init__.py
+++ b/libsemigroups_cppyy/__init__.py
@@ -74,6 +74,11 @@ def compare_version_numbers(supplied, required):
 import cppyy
 import sys
 
+
+def cppyy_version():
+    return cppyy.__version__
+
+
 cppyy.gbl
 
 path = os.environ["PATH"].split(":")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,12 @@ setup(
     author="James D. Mitchell, Nicolas Thiéry",
     author_email="jdm3@st-andrews.ac.uk, Nicolas.Thiery@u-psud.fr",
     license="GPL3",
-    install_requires=["cppyy", "networkx", "pkgconfig", "packaging"],
+    install_requires=[
+        "cppyy>=1.6.1",
+        "networkx>=2.4",
+        "pkgconfig>=0.29.2",
+        "packaging>=20.4",
+    ],
     packages=find_packages(exclude=["tests"]),
     tests_require=["tox"],
     zip_safe=False,

--- a/tests/fpsemi_intf.py
+++ b/tests/fpsemi_intf.py
@@ -51,11 +51,11 @@ def check_validation(self, t):
             + e
         )
 
-    if cppyy_version() <= "1.7.0":
-        with self.assertRaises(TypeError):
+    if compare_version_numbers(cppyy_version(), "1.7.1"):
+        with self.assertRaises(LibsemigroupsException):
             x.validate_word([0, 1, 2])
     else:
-        with self.assertRaises(LibsemigroupsException):
+        with self.assertRaises(TypeError):
             x.validate_word([0, 1, 2])
     try:
         x.validate_word([0, 1, 0, 1])
@@ -175,11 +175,11 @@ def check_operators(self, t):
     self.assertTrue(x.equal_to("bb", "B"))
     self.assertTrue(x.equal_to([1, 1], [2]))
 
-    if cppyy_version() <= "1.7.0":
-        with self.assertRaises(TypeError):
+    if compare_version_numbers(cppyy_version(), "1.7.1"):
+        with self.assertRaises(LibsemigroupsException):
             x.equal_to([1, 1], [5])
     else:
-        with self.assertRaises(LibsemigroupsException):
+        with self.assertRaises(TypeError):
             x.equal_to([1, 1], [5])
 
     with self.assertRaises(TypeError):

--- a/tests/fpsemi_intf.py
+++ b/tests/fpsemi_intf.py
@@ -12,6 +12,7 @@ from libsemigroups_cppyy import (
     microseconds,
     compare_version_numbers,
     libsemigroups_version,
+    cppyy_version,
     FpSemigroup,
 )
 
@@ -40,7 +41,6 @@ def check_validation(self, t):
             "unexpected exception raised for FpSemigroupInterface::validate_letter: "
             + e
         )
-
     with self.assertRaises(TypeError):
         x.validate_word("abc")
     try:
@@ -51,8 +51,12 @@ def check_validation(self, t):
             + e
         )
 
-    with self.assertRaises(TypeError):
-        x.validate_word([0, 1, 2])
+    if cppyy_version() <= "1.7.0":
+        with self.assertRaises(TypeError):
+            x.validate_word([0, 1, 2])
+    else:
+        with self.assertRaises(LibsemigroupsException):
+            x.validate_word([0, 1, 2])
     try:
         x.validate_word([0, 1, 0, 1])
     except Exception as e:
@@ -171,8 +175,13 @@ def check_operators(self, t):
     self.assertTrue(x.equal_to("bb", "B"))
     self.assertTrue(x.equal_to([1, 1], [2]))
 
-    with self.assertRaises(TypeError):
-        x.equal_to([1, 1], [5])
+    if cppyy_version() <= "1.7.0":
+        with self.assertRaises(TypeError):
+            x.equal_to([1, 1], [5])
+    else:
+        with self.assertRaises(LibsemigroupsException):
+            x.equal_to([1, 1], [5])
+
     with self.assertRaises(TypeError):
         x.equal_to("aa", "z")
 

--- a/tests/test_a_froidure_pin.py
+++ b/tests/test_a_froidure_pin.py
@@ -246,7 +246,7 @@ class TestFroidurePin(unittest.TestCase):
             S.word_to_element([0, 1, 0, 1]), Transformation([0, 3, 4, 1, 2])
         )
         self.assertEqual(S.word_to_pos([0, 1, 0, 1]), 15)
-        
+
         S = FroidurePin(Transformation([1, 0, 1]), Transformation([0, 0, 0]))
         S.run()
         if compare_version_numbers(libsemigroups_version(), "1.1.0"):
@@ -254,7 +254,6 @@ class TestFroidurePin(unittest.TestCase):
                 S.rules(),
                 [[[0, 1], [1]], [[1, 1], [1]], [[0, 0, 0], [0]], [[1, 0, 0], [1]]],
             )
-
 
     def test_prefixes_and_suffixes(self):
         S = FroidurePin(Transformation(list(range(1, 5)) + [0]))


### PR DESCRIPTION
Some parts of the tests returned either `LibsemigroupsException` with cppyy verision 1.7.1, or a `TypeError` with cppyy version 1.7.0. This PR fixes this, allowing the tests to pass regardless of the cppyy version.